### PR TITLE
mission8 (#1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/server/springStudy/SpringStudyApplication.java
+++ b/src/main/java/com/server/springStudy/SpringStudyApplication.java
@@ -2,8 +2,10 @@ package com.server.springStudy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class SpringStudyApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/server/springStudy/apiPayload/ApiResponse.java
+++ b/src/main/java/com/server/springStudy/apiPayload/ApiResponse.java
@@ -1,0 +1,40 @@
+package com.server.springStudy.apiPayload;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.server.springStudy.apiPayload.code.BaseCode;
+import com.server.springStudy.apiPayload.code.status.SuccessStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+// [@JsonPropertyOrder] 직렬화에서 property 의 순서 지정 가능 (직렬화 : 자바 객체를 json 형태로 변환)
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+// [ApiResponse] 성공, 실패할 시 리턴할 함수들과 필드들 작성
+// 모든 코드를 ApiResponse 로 리턴함으로써 응답 통일하여 프론트와의 통신을 용이하게 함
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;    // 성공 여부
+    private final String code;  // HTTP 상태코드만으로는 제한적인 정보만 줄 수 있으므로, 더 세부적인 응답 상황을 알려주기 위한 필드
+    private final String message;   // code에 추가적으로 우리에게 익숙한 문자로 상황을 알려주는 필드
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;   // 실제로 클라이언트에게 필요한 데이터가 딤김. 어떤 형태의 값이 올지 모르므로 Generic 으로 설정
+    // 에러 상황에서는 보통 null. null 을 담지 않는 에러 상황도 있음
+
+    // 성공한 경우 응답 생성
+    public static <T> ApiResponse<T> onSuccess(T result) {
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode code, T result) {
+        return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+    }
+
+    // 실패한 경우 응답 생성
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data) {
+        return new ApiResponse<>(false, code, message, data);
+    }
+}

--- a/src/main/java/com/server/springStudy/apiPayload/code/BaseCode.java
+++ b/src/main/java/com/server/springStudy/apiPayload/code/BaseCode.java
@@ -1,0 +1,8 @@
+package com.server.springStudy.apiPayload.code;
+
+// [BaseCode] 인터페이스 BaseCode 를 구체화 하는 Status 에서 아래 두 개의 메소드를 반드시 Override 할 것을 강제
+public interface BaseCode {
+    public ReasonDTO getReason();
+
+    public ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/server/springStudy/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/com/server/springStudy/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package com.server.springStudy.apiPayload.code;
+
+public interface BaseErrorCode {
+
+    public ErrorReasonDTO getReason();
+
+    public ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/server/springStudy/apiPayload/code/ErrorReasonDTO.java
+++ b/src/main/java/com/server/springStudy/apiPayload/code/ErrorReasonDTO.java
@@ -1,0 +1,14 @@
+package com.server.springStudy.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+    private HttpStatus httpStatus;
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/server/springStudy/apiPayload/code/ReasonDTO.java
+++ b/src/main/java/com/server/springStudy/apiPayload/code/ReasonDTO.java
@@ -1,0 +1,14 @@
+package com.server.springStudy.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDTO {
+    private HttpStatus httpStatus;
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/server/springStudy/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/server/springStudy/apiPayload/code/status/ErrorStatus.java
@@ -1,0 +1,57 @@
+package com.server.springStudy.apiPayload.code.status;
+
+import com.server.springStudy.apiPayload.code.BaseErrorCode;
+import com.server.springStudy.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/*
+[Enum 관리에 대한 고찰]
+: 프론트 개발자 입장에서 API 응답의 원인을 정확하게 파악할 수 있도록 code 에도 체계적인 규칙을 정해두자
+
+1. common 에러는 COMMON000 으로 둔다 <- 잘 안쓰지만 마땅하지 않을 때 사용
+2. 관련된 경우마다 code에 명시적으로 표현한다
+	: ex. 멤버 관련이면 MEMBER001, 게시글 관련이면 ARTICLE001 이런 식으로
+3. 2번에 이어서 4000번대를 붙인다. 서버측 잘못은 그냥 COMMON 에러의 서버 에러를 쓰면 됨
+	: MEMBER400_1 아니면 MEMBER4001 이런 식으로
+ */
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+
+    // 개발 과정에서 해당 프로젝트에서 필요한 예외 상황에 대한 enum 추가
+
+    // 기본 에러
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // 에러 테스트
+    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "에러 테스트"),
+
+    // 멤버 관련 에러
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
+    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder().message(message).code(code).isSuccess(false).build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/server/springStudy/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/server/springStudy/apiPayload/code/status/SuccessStatus.java
@@ -1,0 +1,38 @@
+package com.server.springStudy.apiPayload.code.status;
+
+import com.server.springStudy.apiPayload.code.BaseCode;
+import com.server.springStudy.apiPayload.code.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+// [LomBok] 불필요한 코드와 작업을 줄여주는 라이브러리
+// [@AllArgsConstructor] 모든 필드 값을 파라미터로 받는 생성자를 자동으로 생성. 클래스의 모든 필드를 한번에 초기화할 수 있음
+// [@RequiredArgsConstructor] final 이나 @NonNull 로 선언된 필드만을 파라미터로 받는 생성자 생성. 클래스가 의존하는 필드를 간단하게 초기화할 수 있음
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    // 필드 밑에서 사용할 enum 작성. 성공 응답에 새로운 코드를 적고 싶다면 enum 추가
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
+    _CREATED(HttpStatus.CREATED, "COMMON201", "요청 성공 및 리소스 생성됨");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder().code(code).isSuccess(true).message(message).build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .httpStatus(httpStatus)
+                .code(code)
+                .isSuccess(true)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/server/springStudy/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/server/springStudy/apiPayload/exception/ExceptionAdvice.java
@@ -1,0 +1,130 @@
+package com.server.springStudy.apiPayload.exception;
+
+import com.server.springStudy.apiPayload.ApiResponse;
+import com.server.springStudy.apiPayload.code.ErrorReasonDTO;
+import com.server.springStudy.apiPayload.code.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+// [@RestControllerAdvice] 전역적으로 에러를 잡아서 처리 가능하게 하는 역할
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    // build.gradle 에서 validation 의존성 추가 필요
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
+    }
+
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().stream()
+                .forEach(
+                        fieldError -> {
+                            String fieldName = fieldError.getField();
+                            String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                            errors.merge(
+                                    fieldName,
+                                    errorMessage,
+                                    (existingErrorMessage, newErrorMessage) ->
+                                            existingErrorMessage + ", " + newErrorMessage);
+                        });
+
+        return handleExceptionInternalArgs(
+                e, HttpHeaders.EMPTY, ErrorStatus.valueOf("_BAD_REQUEST"), request, errors);
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
+//        e.printStackTrace();
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/com/server/springStudy/apiPayload/exception/GeneralException.java
+++ b/src/main/java/com/server/springStudy/apiPayload/exception/GeneralException.java
@@ -1,0 +1,17 @@
+package com.server.springStudy.apiPayload.exception;
+
+import com.server.springStudy.apiPayload.code.BaseErrorCode;
+import com.server.springStudy.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public ErrorReasonDTO getErrorReason() {return this.code.getReason();}
+
+    public ErrorReasonDTO getErrorReasonHttpStatus() {return this.code.getReasonHttpStatus();}
+}

--- a/src/main/java/com/server/springStudy/apiPayload/exception/handler/TempHandler.java
+++ b/src/main/java/com/server/springStudy/apiPayload/exception/handler/TempHandler.java
@@ -1,0 +1,22 @@
+package com.server.springStudy.apiPayload.exception.handler;
+
+import com.server.springStudy.apiPayload.code.BaseErrorCode;
+import com.server.springStudy.apiPayload.exception.GeneralException;
+
+/*
+[handler]
+: handler 패키지 안에 에러와 관련한 handler 클래스들을 생성
+
+    (ex)
+    user 관련 handler : UserHandler
+    post 관련 handler : PostHandler
+ */
+
+public class TempHandler extends GeneralException {
+
+    public TempHandler(BaseErrorCode errorCode) {
+
+        // super : 부모 클래스의 생성자 호출
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/server/springStudy/converter/TempConverter.java
+++ b/src/main/java/com/server/springStudy/converter/TempConverter.java
@@ -1,12 +1,18 @@
 package com.server.springStudy.converter;
 
-import com.server.springStudy.web.dto.TempResponseDTO;
+import com.server.springStudy.web.dto.TempResponse;
 
 public class TempConverter {
 
-    public static TempResponseDTO.TempTestDTO toTempTestDTO(){
-        return TempResponseDTO.TempTestDTO.builder()
+    public static TempResponse.TempTestDTO toTempTestDTO(){
+        return TempResponse.TempTestDTO.builder()
                 .testString("This is Test")
+                .build();
+    }
+
+    public static TempResponse.TempExceptionDTO toTempExceptionDTO(Integer flag){
+        return TempResponse.TempExceptionDTO.builder()
+                .flag(flag)
                 .build();
     }
 }

--- a/src/main/java/com/server/springStudy/converter/TempConverter.java
+++ b/src/main/java/com/server/springStudy/converter/TempConverter.java
@@ -1,0 +1,12 @@
+package com.server.springStudy.converter;
+
+import com.server.springStudy.web.dto.TempResponseDTO;
+
+public class TempConverter {
+
+    public static TempResponseDTO.TempTestDTO toTempTestDTO(){
+        return TempResponseDTO.TempTestDTO.builder()
+                .testString("This is Test")
+                .build();
+    }
+}

--- a/src/main/java/com/server/springStudy/domain/common/BaseEntity.java
+++ b/src/main/java/com/server/springStudy/domain/common/BaseEntity.java
@@ -9,7 +9,19 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+/*
+ [@MappedSuperclass]
+ JPA 에서 공통 필드나 메소드를 정의하는 추상 클래스를 만들기 위해 사용
+ 독립적인 엔티티는 아니며 이를 상속받는 엔티티 클래스가 필드나 메소드를 공유하게 됨
+ */
 @MappedSuperclass
+/*
+[@EntityListeners]
+JPA 엔티티의 생명주기 이벤트를 감지하여 감사 정보를 자동으로 설정하거나, 특정 로직을 실행하기 위해 사용됨
+(엔티티 감사 정보 : 데이터베이스 엔티티 객체에 대한 생성, 수정 등의 이력을 추적하기 위한 메타데이터)
+[AuditingEntityListener]
+Spring Data JPA에서 제공. 엔티티의 생성일자와 수정일자를 자동으로 설정하는 데 주로 사용
+ */
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 public abstract class BaseEntity {
@@ -18,4 +30,6 @@ public abstract class BaseEntity {
 
     @LastModifiedBy
     private LocalDateTime updatedAt;
+
+
 }

--- a/src/main/java/com/server/springStudy/service/TempService/TempCommandService.java
+++ b/src/main/java/com/server/springStudy/service/TempService/TempCommandService.java
@@ -1,0 +1,4 @@
+package com.server.springStudy.service.TempService;
+
+public interface TempCommandService {
+}

--- a/src/main/java/com/server/springStudy/service/TempService/TempCommandServiceImpl.java
+++ b/src/main/java/com/server/springStudy/service/TempService/TempCommandServiceImpl.java
@@ -1,0 +1,9 @@
+package com.server.springStudy.service.TempService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TempCommandServiceImpl implements TempCommandService {
+}

--- a/src/main/java/com/server/springStudy/service/TempService/TempQueryService.java
+++ b/src/main/java/com/server/springStudy/service/TempService/TempQueryService.java
@@ -1,0 +1,6 @@
+package com.server.springStudy.service.TempService;
+
+public interface TempQueryService {
+
+    void CheckFlag(Integer flag);
+}

--- a/src/main/java/com/server/springStudy/service/TempService/TempQueryServiceImpl.java
+++ b/src/main/java/com/server/springStudy/service/TempService/TempQueryServiceImpl.java
@@ -1,0 +1,38 @@
+package com.server.springStudy.service.TempService;
+
+import com.server.springStudy.apiPayload.code.status.ErrorStatus;
+import com.server.springStudy.apiPayload.exception.handler.TempHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/*
+[Sevice 작성 규칙]
+
+1. GET 요청과 나머지 요청에 대해 아래와 같이 분리
+
+	a. GET 요청에 대한 비즈니스 로직을 처리할 경우
+			TempQueryService
+	b. 나머지 요청에 대한 비즈니스 로직을 처리할 경우
+			TempCommandService
+
+2. 서비스를 만들 경우 인터페이스를 먼저 두고 이를 구체화
+
+	 TempQueryService 인터페이스, TempCommandService 인터페이스를 만들고,
+	 이에 대한 Impl 구체화 클래스를 만든다
+
+3. ********************************************************************************************
+컨트롤러는 **인터페이스를 의존하며** 실제 인터페이스에 대한 구체화 클래스는 Springboot의 의존성 주입을 이용한다
+***********************************************************************************************
+ */
+
+@Service
+@RequiredArgsConstructor
+public class TempQueryServiceImpl implements TempQueryService {
+
+    @Override
+    public void CheckFlag(Integer flag) {
+
+        if (flag == 1)
+            throw new TempHandler(ErrorStatus.TEMP_EXCEPTION);
+    }
+}

--- a/src/main/java/com/server/springStudy/web/controller/TempRestController.java
+++ b/src/main/java/com/server/springStudy/web/controller/TempRestController.java
@@ -1,0 +1,81 @@
+package com.server.springStudy.web.controller;
+
+import com.server.springStudy.apiPayload.ApiResponse;
+import com.server.springStudy.converter.TempConverter;
+import com.server.springStudy.web.dto.TempResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/*
+ 0. @ResponseBody
+
+ [데이터 처리 모델]
+ 동기식 처리 모델 / 비동기식 처리 모델
+
+ [동기 synchronous]
+ 사용자가 데이터를 서버에게 요청하면, 그 서버가 데이터 요청에 따른 응답을 사용자에게 다시 리턴해주기 전까지 사용자는 다른 활동 못하고 기다려야 함
+
+ [비동기 Asynchronous]
+ 서버에게 데이터를 요청한 후, 요청에 따른 응답을 계속 기다리지 않고 다른 외부 활동 수행해도 되고 서버에게 다른 요청을 보내도 됨
+
+ [@RequestBody, @ResponseBody]
+ 웹에서 화면 전환 없이 이루어지는 동작들은 대부분 비동기 통신으로 이루어짐. 비동기 통신을 하기 위해선 (클라->서버 요청 메시지의 Body에, 서버->클라 응답 메시지의 Body에) 데이터를 담아서 보내야 함
+ @RequestBody : 비동기 통신에서 쓰이는 Body 안의 데이터 (JSON 객체) -> 자바 객체 로 변환
+ @ResponseBody : 자바 객체 -> JSON 객체 변환
+
+ 1. @RestController
+
+ [@Controller / @RestController]
+ Controller 를 지정해주기 위한 어노테이션. Response Body 가 생성되는 방식에서 차이가 있음
+
+ [@Controller]
+ 전통적인 SpringMVC의 Controller. 주로 "View" 를 반환하기 위해 사용
+
+ [@RestController]
+ RESTful 웹 서비스의 Controller. @Controller + @ResponseBody 어노테이션이라고 볼 수 있음. 반환하려는 주류는 JSON 형태의 객체 데이터
+ Spring MVC 의 컨트롤러 (@Controller) 를 사용할 때 "데이터" 를 반환해야 하는 경우가 있는데, 이때 자바 객체를 JSON 객체로 변환하기 위해 @ResponseBody 사용. @RestController = @Controller + @ResponseBody
+ */
+@RestController
+@RequestMapping("/temp")
+
+/*
+ 0. Spring 프레임워크의 의존성 주입 방식
+ : 필드 주입 / setter 주입 / 생성자 주입
+
+ 1. 생성자 주입
+ : 객체 생성 시점에 필요한 의존성을 생성자 파라미터로 전달받아 주입하는 방식
+
+ 2. Lombok의 @RequiredArgsConstructor
+
+ [Lombok]
+ 불필요한 코드와 작업을 줄여주는 라이브러리. 다양한 어노테이션 제공
+ @AllArgsConstructor / @RequiredArgsConstructor / @NoArgsConstructor / @Getter / @Builder 등
+
+ [Lombok 사용 이점]
+ 스프링에서는 @Autowired 를 사용해서 생성자 주입 방식으로 의존성 주입을 하는데,
+ Lombok 이 제공하는 생성자 주입 관련 어노테이션을 사용하면, Spring 이 자동으로 생성자를 통해 의존성을 주입하므로 @Autowired 없이도 의존성 주입을 쉽게 할 수 있음
+
+ [@RequiredArgsConstructor]
+ Lombok 의 생성자 주입 관련 어노테이션. final 이나 @NonNull 로 선언된 필드만을 파라미터로 받는 생성자를 자동으로 생성. 따라서 의존성 주입을 더욱 간편하게 할 수 있음
+ 즉, 스프링에서 Lombok 으로 의존성 주입 하는 방법 중에, 생성자 주입을 임의의 코드없이 자동으로 설정해주는 어노테이션
+ 새로운 필드를 추가할 때마다 생성자를 수정해야하는 번거로움을 없애줌
+ */
+@RequiredArgsConstructor
+public class TempRestController {
+
+    @GetMapping("/")
+    // 현재는 <String> 으로 뒀지만 onSuccess 타입을 제네릭스로 했으므로 DTO나 다른 클래스도 가능
+    public ApiResponse<String> stringTest() {
+
+        return ApiResponse.onSuccess("성공!");
+    }
+
+    @GetMapping("/test")
+    // 현재는 <String> 으로 뒀지만 onSuccess 타입을 제네릭스로 했으므로 DTO나 다른 클래스도 가능
+    public ApiResponse<TempResponseDTO.TempTestDTO> test() {
+
+        return ApiResponse.onSuccess(TempConverter.toTempTestDTO());
+    }
+}

--- a/src/main/java/com/server/springStudy/web/controller/TempRestController.java
+++ b/src/main/java/com/server/springStudy/web/controller/TempRestController.java
@@ -2,10 +2,12 @@ package com.server.springStudy.web.controller;
 
 import com.server.springStudy.apiPayload.ApiResponse;
 import com.server.springStudy.converter.TempConverter;
-import com.server.springStudy.web.dto.TempResponseDTO;
+import com.server.springStudy.service.TempService.TempQueryService;
+import com.server.springStudy.web.dto.TempResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /*
@@ -65,6 +67,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class TempRestController {
 
+    // ** 구현체 아닌 인터페이스 작성 (컨트롤러는 인터페이스를 의존하며 실제 인터페이스에 대한 구체화 클래스는 Springboot의 의존성 주입 이용)
+    private final TempQueryService tempQueryService;
+
     @GetMapping("/")
     // 현재는 <String> 으로 뒀지만 onSuccess 타입을 제네릭스로 했으므로 DTO나 다른 클래스도 가능
     public ApiResponse<String> stringTest() {
@@ -73,9 +78,15 @@ public class TempRestController {
     }
 
     @GetMapping("/test")
-    // 현재는 <String> 으로 뒀지만 onSuccess 타입을 제네릭스로 했으므로 DTO나 다른 클래스도 가능
-    public ApiResponse<TempResponseDTO.TempTestDTO> test() {
+    public ApiResponse<TempResponse.TempTestDTO> test() {
 
         return ApiResponse.onSuccess(TempConverter.toTempTestDTO());
+    }
+
+    @GetMapping("/exception")
+    public ApiResponse<TempResponse.TempExceptionDTO> exceptionAPI(@RequestParam Integer flag){
+
+        tempQueryService.CheckFlag(flag);
+        return ApiResponse.onSuccess(TempConverter.toTempExceptionDTO(flag));
     }
 }

--- a/src/main/java/com/server/springStudy/web/dto/TempResponse.java
+++ b/src/main/java/com/server/springStudy/web/dto/TempResponse.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 
 // DTO들은 큰 묶음으로 클래스를 만들고 내부적으로 static 클래스를 만드는 게 좋음
 // DTO 자체는 많은 곳에서 사용될 수 있으므로 static class 로 만들면, 매번 class 파일을 만들 필요도 없고, 범용적으로 DTO 를 사용할 수 있음
-public class TempResponseDTO {
+public class TempResponse {
 
     @Builder
     @Getter
@@ -21,7 +21,7 @@ public class TempResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class TestExceptionDTO{
+    public static class TempExceptionDTO{
         Integer flag;
     }
 }

--- a/src/main/java/com/server/springStudy/web/dto/TempResponseDTO.java
+++ b/src/main/java/com/server/springStudy/web/dto/TempResponseDTO.java
@@ -1,0 +1,27 @@
+package com.server.springStudy.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// DTO들은 큰 묶음으로 클래스를 만들고 내부적으로 static 클래스를 만드는 게 좋음
+// DTO 자체는 많은 곳에서 사용될 수 있으므로 static class 로 만들면, 매번 class 파일을 만들 필요도 없고, 범용적으로 DTO 를 사용할 수 있음
+public class TempResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TempTestDTO{
+        String testString;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TestExceptionDTO{
+        Integer flag;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,4 +15,4 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: create
+          auto: update


### PR DESCRIPTION
1️⃣ feat :성공 응답 API

[API 응답 통일 세팅]
1. ReasonDTO
2. BaseResponse
3. SuccessStatus (implements BaseCode)
4. BaseReponse

[테스트 케이스]
1. Controller 작성
TempRestController에 test() 작성

2️⃣ feat : 에러 핸들러 구현

[에러 처리]
1. ErrorReasonDTO
2. BaseErrorCode
3. ErrorStatus (implements BaseErrorCode)
6. GeneralException (extends RuntimeException)
7. ExceptionAdvice (extends ResponseEntityExceptionHandler)

[테스트 케이스]
1. ErrorStatus에 새로운 에러 케이스 추가
TEMP_EXCEPTION
2. handler 패키지에 temp에 대한 Handler 추가
TempHandler
3. DTO 추가
TempResponse.TempExceptionDTO
(TempResponse에 TempExceptionDTO 추가)
4. Converter 작성
TempConverter.toTempExceptionDTO
(TempConverter에 toTempExceptionDTO 작성)
5. Controller 작성
TempRestController에 exceptionAPI 작성
8. Service 작성
TempQueryService (interface)
TempCommandQueryImpl (implements TempQueryService)
9. Controller 완성

[작동 로직]
1. Service에서 throw new TempHandler (해당 핸들러)
2. TempHandler extends GeneralException 에서 super(errorCode); -> 부모 클래스인 GeneralException의 생성자 호출 ( = GeneralException 클래스에서, @AllArgsConstructor를 통해 만들어진 생성자가 호출됨)
3. GeneralException은 다시, GeneralException extends RuntimeException 이고, 해당 에러가 런타임에서 발생한 에러이므로 Exception으로써 MasterExceptionHandler가 감지
: HOW? ExceptionAdvice가 @RestControllerAdvice를 가지고 있기 때문.
: @RestControllerAdvice는 @RestController가 붙은 대상에서 Exception이 발생하는 것을 감지하는 역할
4. ExceptionAdvice의 onThrowException에 @ExceptionHandler(value = GeneralException.class) 되어있으므로 onThrowException 호출됨. onThrowException에서 GeneralException에 대해 다시 한번 오버로딩 된 함수(handleExceptionInternal)를 호출
5. handleExceptionInternal에서는 상속 받은 부모 클래스의 생성자를 호출 <- return super.handleExceptionInternal();
6. 해당 코드 (부모 클래스의 생성자 = handleExceptionInternal) 를 확인해보면, 여기에서 응답을 보내는 것을 확인할 수 있음

: Service에서 throw new TempHandler가 실행되게 되면서, controller로 가지 않고, 바로 바로 Exception handler에 의해 응답이 보내지게 되는 것. 
Service의 메소드를 @RestController가 붙은 메소드에서 호출을 했기 때문에, 결국 컨트롤러에서 Exception이 발생 한 것으로 판단한 것.
마찬가지로 Converter에서 Exception을 발생시켜도 결국 컨트롤러에서 Converter를 호출한 것이므로 Exception Handler에 잡히게 됨

