### PR TITLE
🐛 fix : 리뷰 저장 시, 이미지리스트 null 에러 해결

### DIFF
--- a/src/main/java/com/server/springStudy/converter/ReviewConverter.java
+++ b/src/main/java/com/server/springStudy/converter/ReviewConverter.java
@@ -5,6 +5,8 @@ import com.server.springStudy.domain.entity.Review;
 import com.server.springStudy.domain.entity.Store;
 import com.server.springStudy.web.dto.store.ReviewCreateRequest;
 
+import java.util.ArrayList;
+
 public class ReviewConverter {
 
     public static Review toCreateReview(Member member, Store store, ReviewCreateRequest request) {
@@ -14,6 +16,7 @@ public class ReviewConverter {
                 .store(store)
                 .score(request.score())
                 .content(request.content())
+                .reviewImageList(new ArrayList<>()) // ** 리뷰 엔티티 생성할 때, 빈 리스트로 초기화 해야함 <- eroor : entity.Review.getReviewImageList()" is null
                 .build();
     }
 }

--- a/src/main/java/com/server/springStudy/converter/ReviewConverter.java
+++ b/src/main/java/com/server/springStudy/converter/ReviewConverter.java
@@ -1,13 +1,17 @@
 package com.server.springStudy.converter;
 
+import com.server.springStudy.domain.entity.Member;
 import com.server.springStudy.domain.entity.Review;
+import com.server.springStudy.domain.entity.Store;
 import com.server.springStudy.web.dto.store.ReviewCreateRequest;
 
 public class ReviewConverter {
 
-    public static Review toCreateReview(ReviewCreateRequest request) {
+    public static Review toCreateReview(Member member, Store store, ReviewCreateRequest request) {
 
         return Review.builder()
+                .member(member)
+                .store(store)
                 .score(request.score())
                 .content(request.content())
                 .build();

--- a/src/main/java/com/server/springStudy/service/storeService/StoreCommandService.java
+++ b/src/main/java/com/server/springStudy/service/storeService/StoreCommandService.java
@@ -2,16 +2,11 @@ package com.server.springStudy.service.storeService;
 
 import com.server.springStudy.domain.entity.Mission;
 import com.server.springStudy.domain.entity.Review;
-import com.server.springStudy.domain.entity.ReviewImage;
 import com.server.springStudy.web.dto.store.MissionCreateRequest;
 import com.server.springStudy.web.dto.store.ReviewCreateRequest;
 
-import java.util.List;
-
 public interface StoreCommandService {
     Review createReview(Long memberId, Long storeId, ReviewCreateRequest request);
-
-    List<ReviewImage> createReviewImage(Review review, ReviewCreateRequest request);
 
     Mission createMission(Long storeId, MissionCreateRequest request);
 }

--- a/src/main/java/com/server/springStudy/service/storeService/StoreCommandServiceImpl.java
+++ b/src/main/java/com/server/springStudy/service/storeService/StoreCommandServiceImpl.java
@@ -10,6 +10,7 @@ import com.server.springStudy.repository.*;
 import com.server.springStudy.web.dto.store.MissionCreateRequest;
 import com.server.springStudy.web.dto.store.ReviewCreateRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,7 @@ import java.util.List;
 import static com.server.springStudy.apiPayload.code.status.ErrorStatus.MEMBER_NOT_FOUND;
 import static com.server.springStudy.apiPayload.code.status.ErrorStatus.STORE_NOT_FOUND;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -26,7 +28,6 @@ public class StoreCommandServiceImpl implements StoreCommandService {
     private final StoreRepository storeRepository;
     private final MemberRepository memberRepository;
     private final ReviewRepository reviewRepository;
-    private final ReviewImageRepository reviewImageRepository;
     private final MissionRepository missionRepository;
 
     @Override
@@ -41,8 +42,8 @@ public class StoreCommandServiceImpl implements StoreCommandService {
         Review newReview = ReviewConverter.toCreateReview(member, store, request);
 
         List<ReviewImage> reviewImageList = ReviewImageConverter.toReviewImageList(request.imageUrl());
-        reviewImageList.forEach(reviewImage -> {reviewImage.setReview(newReview);
-        });
+        log.info("reviewImageList = {}", reviewImageList);
+        reviewImageList.forEach(reviewImage -> {reviewImage.setReview(newReview);});
 
         return reviewRepository.save(newReview);
     }

--- a/src/main/java/com/server/springStudy/service/storeService/StoreCommandServiceImpl.java
+++ b/src/main/java/com/server/springStudy/service/storeService/StoreCommandServiceImpl.java
@@ -32,31 +32,19 @@ public class StoreCommandServiceImpl implements StoreCommandService {
     @Override
     public Review createReview(Long memberId, Long storeId, ReviewCreateRequest request) {
 
-        Review newReview = ReviewConverter.toCreateReview(request);
-
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(MEMBER_NOT_FOUND));
 
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new StoreHandler(STORE_NOT_FOUND));
 
-        newReview.setMember(member);
-        newReview.setStore(store);
-
-        return reviewRepository.save(newReview);
-    }
-
-    @Override
-    public List<ReviewImage> createReviewImage(Review review, ReviewCreateRequest request) {
+        Review newReview = ReviewConverter.toCreateReview(member, store, request);
 
         List<ReviewImage> reviewImageList = ReviewImageConverter.toReviewImageList(request.imageUrl());
-
-        reviewImageList.forEach(reviewImage -> {
-            reviewImage.setReview(review);
-            reviewImageRepository.save(reviewImage);
+        reviewImageList.forEach(reviewImage -> {reviewImage.setReview(newReview);
         });
 
-        return reviewImageList;
+        return reviewRepository.save(newReview);
     }
 
     @Override

--- a/src/main/java/com/server/springStudy/web/controller/StoreRestController.java
+++ b/src/main/java/com/server/springStudy/web/controller/StoreRestController.java
@@ -3,7 +3,6 @@ package com.server.springStudy.web.controller;
 import com.server.springStudy.apiPayload.ApiResponse;
 import com.server.springStudy.domain.entity.Mission;
 import com.server.springStudy.domain.entity.Review;
-import com.server.springStudy.domain.entity.ReviewImage;
 import com.server.springStudy.service.storeService.StoreCommandService;
 import com.server.springStudy.web.dto.store.MissionCreateRequest;
 import com.server.springStudy.web.dto.store.MissionCreateResponse;
@@ -11,10 +10,10 @@ import com.server.springStudy.web.dto.store.ReviewCreateRequest;
 import com.server.springStudy.web.dto.store.ReviewCreateResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/store")
@@ -26,13 +25,13 @@ public class StoreRestController {
     public ApiResponse<ReviewCreateResponse> createReview(
             @RequestBody @Valid ReviewCreateRequest request,
             @PathVariable Long storeId,
-            @RequestHeader Long memberId
-            ) {
+            @RequestHeader Long memberId) {
+
+        log.info("reviewImageList = {}", request.imageUrl());
 
         Review newReview = storeCommandService.createReview(memberId, storeId, request);
-        List<ReviewImage> reviewImageList = storeCommandService.createReviewImage(newReview, request);
 
-        return ApiResponse.onSuccess(ReviewCreateResponse.from(newReview.getId(), reviewImageList));
+        return ApiResponse.onSuccess(ReviewCreateResponse.of(newReview));
     }
 
     @PostMapping("/{storeId}/mission")

--- a/src/main/java/com/server/springStudy/web/dto/store/ReviewCreateResponse.java
+++ b/src/main/java/com/server/springStudy/web/dto/store/ReviewCreateResponse.java
@@ -1,5 +1,6 @@
 package com.server.springStudy.web.dto.store;
 
+import com.server.springStudy.domain.entity.Review;
 import com.server.springStudy.domain.entity.ReviewImage;
 
 import java.util.List;
@@ -8,10 +9,10 @@ public record ReviewCreateResponse(
         Long reviewId,
         List<Long> reviewImageIdList
 ) {
-    public static ReviewCreateResponse from(Long reviewId, List<ReviewImage> reviewImageIdList) {
+    public static ReviewCreateResponse of(Review review) {
         return new ReviewCreateResponse(
-                reviewId,
-                reviewImageIdList.stream().map(ReviewImage::getId).toList()
+                review.getId(),
+                review.getReviewImageList().stream().map(ReviewImage::getId).toList()
         );
     }
 }


### PR DESCRIPTION
: JPA CascadeType.ALL
: converter에서 엔티티 생성 시, 리스트 초기화

**[기존 로직]**

1. controller에서 service.createReview 호출 -> review save
2. controller에서 service.createReview ImgaeList 호출 -> reviewImage save

이렇게 리뷰, 리뷰 이미지 저장 로직 각각 구현

![리뷰 추가 에러](https://github.com/yewonahn/spring-study/assets/78153914/bb12da81-0d40-4dbc-9a4a-23c9d12bbe26)


**[수정1]**

createReview에서 reviewImage 객체도 생성 후, review save


**[연관 관계 편의 메서드, cascade = CascadeType.ALL]**
1. ReviewImage 엔티티에서 setReview 메서드 -> 연관 관계 편의 메서드 사용으로 연관 관계 설정

2. ReviewImage 엔티티에서

@OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
    private List<ReviewImage> reviewImageList = new ArrayList<>();

cascade = CascadeType.ALL 사용했으므로 부모 엔티티 Review 저장할 때 자식 엔티티 ReviewImage들도 함께 저장됨. 따라서 자식 엔티티는 repository.save 따로 호출 없이도 db에 저장됨

**[수정2]**

Review 엔티티의 reviewImageList 필드 초기화 안함 -> null로 초기화되어 있어서 에러 발생

**ReviewConverter.toReview에서 Review 엔티티 생성할 때 reviewImageList 초기화해줘야 함**

![image](https://github.com/yewonahn/spring-study/assets/78153914/1b5a2e9c-0667-45a8-b0a7-72de3fcd2b4f)


