### PR TITLE
🔨 refactor : setStore 로직 변경

### DIFF
--- a/src/main/java/com/server/springStudy/converter/MissionConverter.java
+++ b/src/main/java/com/server/springStudy/converter/MissionConverter.java
@@ -1,14 +1,16 @@
 package com.server.springStudy.converter;
 
 import com.server.springStudy.domain.entity.Mission;
+import com.server.springStudy.domain.entity.Store;
 import com.server.springStudy.web.dto.store.MissionCreateRequest;
 
 public class MissionConverter {
-    public static Mission toMission(MissionCreateRequest request) {
+    public static Mission toMission(Store store, MissionCreateRequest request) {
         return Mission.builder()
                 .missionSpec(request.missionSpec())
                 .point(request.point())
                 .deadline(request.deadline())
+                .store(store)
                 .build();
     }
 }

--- a/src/main/java/com/server/springStudy/domain/entity/Mission.java
+++ b/src/main/java/com/server/springStudy/domain/entity/Mission.java
@@ -31,9 +31,4 @@ public class Mission extends BaseEntity {
 
     @OneToMany(mappedBy = "mission", cascade = CascadeType.ALL)
     private List<MemberMission> memberMissionList = new ArrayList<>();
-
-    public void setStore(Store store) {
-        this.store = store;
-        store.getMissionList().add(this);
-    }
 }

--- a/src/main/java/com/server/springStudy/service/storeService/StoreCommandServiceImpl.java
+++ b/src/main/java/com/server/springStudy/service/storeService/StoreCommandServiceImpl.java
@@ -51,12 +51,10 @@ public class StoreCommandServiceImpl implements StoreCommandService {
     @Override
     public Mission createMission(Long storeId, MissionCreateRequest request) {
 
-        Mission newMission = MissionConverter.toMission(request);
-
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new StoreHandler(STORE_NOT_FOUND));
 
-        newMission.setStore(store);
+        Mission newMission = MissionConverter.toMission(store, request);
 
         return missionRepository.save(newMission);
     }


### PR DESCRIPTION
단방향이므로 연관 관계 매핑 컨버터에서 설정

(양방향 연관 관계 설정 : converter 보단 service에서)

[테스트 결과]
![image](https://github.com/yewonahn/spring-study/assets/78153914/b9ff765b-f72d-4119-9c2a-92cb148b14cd)
