### PR TITLE
🐛 fix : 배포 스크립트 수정 (#27)

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -14,13 +14,13 @@ jobs:
 
     steps:
       - name: Checkout  # 빌드할 코드를 가져옴 (name은 임의로 설정하면 됨)
-        uses: actions/checkout@v2 # 현재 디렉토리인 .github의 위치(현재 최상단)에 있는 파일들 모두 build gradle의 대상이 됨
+        uses: actions/checkout@v4 # 현재 디렉토리인 .github의 위치(현재 최상단)에 있는 파일들 모두 build gradle의 대상이 됨
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          java-version: 17  # (5) 자바 설치
-          distribution: 'adopt'
+          java-version: '17'  # (5) 자바 설치
+          distribution: 'temurin'
 
       - name: Grant execute permission for gradlew  # 새로 들어갈 컴퓨터의 gradlew에 권한을 준다 (리눅스 명령어)
         run: chmod +x ./gradlew


### PR DESCRIPTION
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, actions/setup-java@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.