### PR TITLE
🐛 fix : 배포 스크립트 수정 (#27)

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -46,7 +46,7 @@ jobs:
           mkdir -p deploy
           cp build/libs/*.jar deploy/application.jar
           cp Procfile deploy/Procfile
-          cp -r .ebextensions-dev deploy/.ebextensions
+          cp -r .ebextensions-dev deploy/.ebextensions-dev
           cp -r .platform deploy/.platform
           cd deploy && zip -r deploy.zip .
 


### PR DESCRIPTION
Run mkdir -p deploy
cp: cannot stat '.ebextensions-dev': No such file or directory Error: Process completed with exit code 1.