### PR TITLE
🔨 refactor : global 에러 처리 추가 (#24)

### DIFF
--- a/src/main/java/com/server/springStudy/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/server/springStudy/apiPayload/exception/ExceptionAdvice.java
@@ -57,23 +57,24 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         Map<String, String> errors = new LinkedHashMap<>();
 
         // 에러 필드와 메세지 추가해주기 위해
-        e.getBindingResult().getFieldErrors().stream()
-                .forEach(
-                        fieldError -> {
-                            String fieldName = fieldError.getField();
-                            String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
-                            errors.merge(
-                                    fieldName,
-                                    errorMessage,
-                                    (existingErrorMessage, newErrorMessage) ->
-                                            existingErrorMessage + ", " + newErrorMessage);
-                        });
+        e.getBindingResult().getFieldErrors().stream().forEach(fieldError -> {
+            String fieldName = fieldError.getField();
+            String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+            errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+        });
+
+        // 타입 에러 처리 (global 에러)
+        e.getBindingResult().getGlobalErrors().forEach(globalError -> {
+            String objectName = globalError.getObjectName();
+            String errorMessage = globalError.getDefaultMessage();
+            errors.put(objectName, errorMessage);
+        });
+
 
         log.info("예외 처리 : handleMethodArgumentNotValid");
 
         // 수집된 에러 메시지들을 포함하여 사용자 정의 응답 생성
-        return handleExceptionInternalArgs(
-                e, HttpHeaders.EMPTY, ErrorStatus.valueOf("_BAD_REQUEST"), request, errors);
+        return handleExceptionInternalArgs(e, HttpHeaders.EMPTY, ErrorStatus.valueOf("_BAD_REQUEST"), request, errors);
     }
 
     /** 예외 처리 메서드 : 모든 종류의 예외 처리 */


### PR DESCRIPTION
가게의 미션을 도전 중인 미션에 추가하는 기능 (#15) 에서,
MemberMissionCreateRequest에서 받아온 id를 통해 해당 멤버가 이미 참여하는 미션인지 검증하는 @AlreadyExistMemberMission 커스텀 어노테이션을 생성했었음 (#18)

1. 이미 도전 중인 미션인 경우, 에러 응답에서 result에서 정확한 에러 메세지를 확인할 수 없었음
![기존](https://github.com/yewonahn/spring-study/assets/78153914/716013a6-081b-49c6-982d-bfd028382196)

[기존 로직]
![image](https://github.com/yewonahn/spring-study/assets/78153914/3d7d2f15-88ad-4de7-a345-89ffa4ffc702)


[기존 응답]
{
  "isSuccess": false,
  "code": "COMMON400",
  "message": "잘못된 요청입니다.",
  "result": {}
}


2. 이미 참여하는 미션인지 검증하기 위해선 memberId, storeId가 필요하므로 해당 커스텀 어노테이션을 클래스(MemberMissionCreateRequest)에 적용하도록 구현했음. 해당 DTO에서 @AlreadyExistMemberMission 검증에서 에러가 발생한 경우, 전역 오류 global 에러에 해당. 따라서 global 에러 처리를 위한 로직 추가 필요

3. 추가한 이후 해결
![변경후](https://github.com/yewonahn/spring-study/assets/78153914/e596c350-b635-47a4-b8f4-6e7f5b2d6147)

[추가한 이후 응답 결과]
{
  "isSuccess": false,
  "code": "COMMON400",
  "message": "잘못된 요청입니다.",
  "result": {
    "memberMissionCreateRequest": "IS_ALREADY_ON_GOING"
  }
}